### PR TITLE
Security: bump nokogiri and net-imap

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -139,7 +139,7 @@ GEM
       drb (~> 2.0)
       prism (~> 1.5)
     msgpack (1.8.0)
-    net-imap (0.6.3)
+    net-imap (0.6.4)
       date
       net-protocol
     net-pop (0.1.2)
@@ -154,7 +154,7 @@ GEM
       net-protocol
     net-ssh (7.3.2)
     nio4r (2.7.5)
-    nokogiri (1.19.2-x86_64-linux-gnu)
+    nokogiri (1.19.3-x86_64-linux-gnu)
       racc (~> 1.4)
     ostruct (0.6.3)
     parallel (2.0.1)


### PR DESCRIPTION
## Summary
- Bump nokogiri 1.19.2 -> 1.19.3
- Bump net-imap 0.6.3 -> 0.6.4

Addresses Dependabot security alerts. Dependabot PRs #45 and #46 will auto-close.

## Test plan
- [x] `bundle update nokogiri net-imap` completed successfully
- [x] `bin/rails runner "Rails.application.eager_load!"` passes